### PR TITLE
Add attributes and message attributes to output.

### DIFF
--- a/nodes/AwsSqsTrigger/AwsSqsTrigger.node.ts
+++ b/nodes/AwsSqsTrigger/AwsSqsTrigger.node.ts
@@ -166,6 +166,8 @@ export class AwsSqsTrigger implements INodeType {
 		const receiveMessageParams = [
 			'Version=2012-11-05',
 			`Action=ReceiveMessage`,
+			'MessageAttributeName=All',
+			'AttributeName=All',
 		];
 
 		if (options.visibilityTimeout) {


### PR DESCRIPTION
In many cases, having access to the attributes of an SQS message can be
useful.  For example, I use a "destination" message attribute that
allows special handling and routing of a message within a workflow. I
imagine that others users of n8n and this plugin may also have use of
the generic SQS attributes, such as `SenderId` and
`ApproximateReceiveCount`.

This commit adds `MessageAttributeName=All` and `AttributeName=All` to
`receiveMessageParams`. This enables the inclusion of all attributes in
the response payload. I feel that these attributes are important enough
that I would expect them to always be included.

An example output follows:

```json
[
    {
        "MessageId": "c4f3a344-d4fd-4135-9b40-b66e058f791d",
        "ReceiptHandle": "...",
        "MD5OfBody": "59713...",
        "MD5OfMessageAttributes": "e65c8...",
        "Body": "some message",
        "Attribute": [
            {
                "Name": "SenderId",
                "Value": "..."
            },
            {
                "Name": "ApproximateFirstReceiveTimestamp",
                "Value": "1662224388373"
            },
            {
                "Name": "ApproximateReceiveCount",
                "Value": "19"
            },
            {
                "Name": "SentTimestamp",
                "Value": "1662224388373"
            }
        ],
        "MessageAttribute": {
            "Name": "destination",
            "Value": {
                "StringValue": "40484c7b-0fe6-42b5-8956-9768f5a9cdd4",
                "DataType": "String"
            }
        }
    }
]
```